### PR TITLE
fix rynthid wands

### DIFF
--- a/sql/weenies/Weapons/Rynthid/51989 Rynthid Tentacle Wand.sql
+++ b/sql/weenies/Weapons/Rynthid/51989 Rynthid Tentacle Wand.sql
@@ -12,8 +12,7 @@ VALUES (51989,   1,      32768) /* ItemType - Caster */
      , (51989,  19,      10000) /* Value */
      , (51989,  33,          1) /* Bonded - Bonded */
      , (51989,  45,         16) /* DamageType - Fire */
-     , (51989,  52,          1) /* ParentLocation - RightHand */
-     , (51989,  53,          1) /* PlacementPosition - RightHandCombat */
+     , (51989,  46,        512) /* DefaultCombatStyle - Magic */
      , (51989,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (51989,  94,         16) /* TargetType - Creature */
      , (51989, 106,        475) /* ItemSpellcraft */
@@ -50,11 +49,11 @@ VALUES (51989,   1, 'Rynthid Tentacle Wand') /* Name */
      , (51989,  33, 'TentacleWeaponPickup') /* Quest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (51989,   1,   33561603) /* Setup */
-     , (51989,   3,  536870932) /* SoundTable */
-     , (51989,   6,   67111919) /* PaletteBase */
-     , (51989,   8,  100693234) /* Icon */
-     , (51989,  22,  872415275) /* PhysicsEffectTable */;
+VALUES (51989,   1, 0x02001C03) /* Setup */
+     , (51989,   3, 0x20000014) /* SoundTable */
+     , (51989,   6, 0x04000BEF) /* PaletteBase */
+     , (51989,   8, 0x060074F2) /* Icon */
+     , (51989,  22, 0x3400002B) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (51989,  3964,      2)  /* Epic Focus */

--- a/sql/weenies/Weapons/Rynthid/51990 Life-attuned Rynthid Tentacle Wand.sql
+++ b/sql/weenies/Weapons/Rynthid/51990 Life-attuned Rynthid Tentacle Wand.sql
@@ -12,8 +12,7 @@ VALUES (51990,   1,      32768) /* ItemType - Caster */
      , (51990,  19,      10000) /* Value */
      , (51990,  33,          1) /* Bonded - Bonded */
      , (51990,  45,         16) /* DamageType - Fire */
-     , (51990,  52,          1) /* ParentLocation - RightHand */
-     , (51990,  53,          1) /* PlacementPosition - RightHandCombat */
+     , (51990,  46,        512) /* DefaultCombatStyle - Magic */
      , (51990,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (51990,  94,         16) /* TargetType - Creature */
      , (51990, 106,        475) /* ItemSpellcraft */
@@ -50,11 +49,11 @@ VALUES (51990,   1, 'Life-attuned Rynthid Tentacle Wand') /* Name */
      , (51990,  33, 'TentacleWeaponPickup') /* Quest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (51990,   1,   33561603) /* Setup */
-     , (51990,   3,  536870932) /* SoundTable */
-     , (51990,   6,   67111919) /* PaletteBase */
-     , (51990,   8,  100693234) /* Icon */
-     , (51990,  22,  872415275) /* PhysicsEffectTable */;
+VALUES (51990,   1, 0x02001C03) /* Setup */
+     , (51990,   3, 0x20000014) /* SoundTable */
+     , (51990,   6, 0x04000BEF) /* PaletteBase */
+     , (51990,   8, 0x060074F2) /* Icon */
+     , (51990,  22, 0x3400002B) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (51990,  3964,      2)  /* Epic Focus */

--- a/sql/weenies/Weapons/Rynthid/51991 Nether-attuned Rynthid Tentacle Wand.sql
+++ b/sql/weenies/Weapons/Rynthid/51991 Nether-attuned Rynthid Tentacle Wand.sql
@@ -12,8 +12,7 @@ VALUES (51991,   1,      32768) /* ItemType - Caster */
      , (51991,  19,      10000) /* Value */
      , (51991,  33,          1) /* Bonded - Bonded */
      , (51991,  45,       1024) /* DamageType - Nether */
-     , (51991,  52,          1) /* ParentLocation - RightHand */
-     , (51991,  53,          1) /* PlacementPosition - RightHandCombat */
+     , (51991,  46,        512) /* DefaultCombatStyle - Magic */
      , (51991,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (51991,  94,         16) /* TargetType - Creature */
      , (51991, 106,        475) /* ItemSpellcraft */
@@ -50,11 +49,11 @@ VALUES (51991,   1, 'Nether-attuned Rynthid Tentacle Wand') /* Name */
      , (51991,  33, 'TentacleWeaponPickup') /* Quest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (51991,   1,   33561603) /* Setup */
-     , (51991,   3,  536870932) /* SoundTable */
-     , (51991,   6,   67111919) /* PaletteBase */
-     , (51991,   8,  100693234) /* Icon */
-     , (51991,  22,  872415275) /* PhysicsEffectTable */;
+VALUES (51991,   1, 0x02001C03) /* Setup */
+     , (51991,   3, 0x20000014) /* SoundTable */
+     , (51991,   6, 0x04000BEF) /* PaletteBase */
+     , (51991,   8, 0x060074F2) /* Icon */
+     , (51991,  22, 0x3400002B) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (51991,  3964,      2)  /* Epic Focus */


### PR DESCRIPTION
at some point wands were broken so you could not stay in casting mode.

the wrong combat style/weapon placemet was on the wands.
maybe during Flaggs patch from foredawn.